### PR TITLE
Add rackspace cloud monitoring.

### DIFF
--- a/rackspace-cloud-monitoring/README.md
+++ b/rackspace-cloud-monitoring/README.md
@@ -1,0 +1,36 @@
+## Rackspace Cloud Monitoring
+
+Rackspace Cloud Monitoring analyzes cloud services and dedicated infrastructure
+using a simple, yet powerful API. The API currently includes monitoring for
+external services. The key benefits you receive from using this API include the
+following:
+
+### Use of Domain Specific Language I(DSL)
+The Rackspace Cloud Monitoring API uses a DSL, which makes it a powerful tool
+for configuring advanced monitoring features. For example, typically complex
+tasks, such as defining triggers on thresholds for metrics or performing an
+inverse string match become much easier with a concise, special purpose language
+created for defining alarms. For more information, see Alarms.
+
+### Monitoring from Multiple Datacenters
+Rackspace Cloud Monitoring allows you to simultaneously monitor the performance
+of different resources from multiple datacenters and provides a clear picture of
+overall system health. It includes tunable parameters to interpret mixed results
+which help you to create deliberate and accurate alerting policies. See Alert
+Policies for more information.
+
+### Alarms and Notifications
+When an alarm occurs on a monitored resource, Rackspace Cloud Monitoring sends
+you a notification so that you can take the appropriate action to either prevent
+an adverse situation from occurring or rectify a situation that has already
+occurred. These notifications are sent based on the severity of the alert as
+defined in the notification plan.
+
+## Links
+
+[Documentation](http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/overview.html)
+
+## Contact
+
+* IRC - #cloudmonitoring @ Freenode
+* Email - cmbeta [at] rackspace [dot] com


### PR DESCRIPTION
I didn't see a folder for API driven monitoring services such as Amazon CloudWatch, Server Density, Cloudkick, etc. so I hope that's OK.

If it is, let me know and I will also add folders for other services.
